### PR TITLE
Move react to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,9 @@
     "brcast": "^2.0.0",
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
-    "prop-types": "^15.5.8",
+    "prop-types": "^15.5.8"
+  },
+  "peerDependencies": {
     "react": "^15.5.4"
   }
 }


### PR DESCRIPTION
Hi,

Trying the new beta of react 16 broke my project because theming has react as a dependency. (then 2 versions of react are installed)

Moving it to peerDependencies solves the issue.