### PR TITLE
fix: WithTheme HOC should hoist non-react static properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
   },
   "dependencies": {
     "brcast": "^2.0.0",
+    "hoist-non-react-statics": "^2.3.0",
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
     "prop-types": "^15.5.8",

--- a/src/create-with-theme.js
+++ b/src/create-with-theme.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import channel from './channel';
 import createThemeListener from './create-theme-listener';
+import hoist from 'hoist-non-react-statics';
 
 const getDisplayName = Component =>
   Component.displayName || Component.name || 'Component';
 
 export default function createWithTheme(CHANNEL = channel) {
   const themeListener = createThemeListener(CHANNEL);
-  return Component =>
+  return Component => {
     class WithTheme extends React.Component {
       static displayName = `WithTheme(${getDisplayName(Component)})`;
       static contextTypes = themeListener.contextTypes;
@@ -31,4 +32,9 @@ export default function createWithTheme(CHANNEL = channel) {
         return <Component theme={theme} {...this.props} />;
       }
     };
+
+    hoist(WithTheme, Component);
+
+    return WithTheme;
+  }
 }

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -232,3 +232,26 @@ test(`withTheme(Comp) receives theme updates even through PureComponent`, t => {
     `withTheme(Comp) should receive theme updates even through PureComponent`,
   );
 });
+
+test(`withTheme(Comp) hoists non-react static class properties`, t => {
+  const withTheme = createWithTheme();
+
+  class ExampleComponent extends Component {
+    static displayName = 'foo';
+    static someSpecialStatic = 'bar';
+  }
+
+  const ComponentWithTheme = withTheme(ExampleComponent);
+
+  t.deepEqual(
+    ComponentWithTheme.displayName,
+    'WithTheme(foo)',
+    `withTheme(Comp) should not hoist react static properties`,
+  );
+
+  t.deepEqual(
+    ComponentWithTheme.someSpecialStatic,
+    ExampleComponent.someSpecialStatic,
+    `withTheme(Comp) should hoist non-react static properties`,
+  );
+});


### PR DESCRIPTION
This allows the various features of styling libraries that rely
on static property tagging to work when wrapped with the `withTheme`
HOC.