### PR TITLE
chore: move react + prop-types to peerDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,8 +84,10 @@
     "eslint-config-prettier": "^2.1.0",
     "eslint-plugin-react": "^7.0.1",
     "eslint-plugin-require-path-exists": "^1.1.7",
+    "prop-types": "^15.5.8",
     "npm-run-all": "^4.0.2",
     "nyc": "^11.0.2",
+    "react": "^15.5.8",
     "react-dom": "^15.5.4",
     "react-test-renderer": "^15.5.4",
     "rimraf": "^2.6.1"
@@ -93,8 +95,10 @@
   "dependencies": {
     "brcast": "^2.0.0",
     "is-function": "^1.0.1",
-    "is-plain-object": "^2.0.1",
-    "prop-types": "^15.5.8",
-    "react": "^15.5.4"
+    "is-plain-object": "^2.0.1"
+  },
+  "peerDependencies": {
+    "react": ">= 15.5",
+    "prop-types": ">= 15.5"
   }
 }


### PR DESCRIPTION
Also loosened the versioning to make future updates easier.