### PR TITLE
chore: enable nyc caching; more stable coverage numbers

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
       "src/*test*"
     ],
     "all": true,
+    "cache": true,
     "reporter": [
       "lcov",
       "text"


### PR DESCRIPTION
I noticed some variance between coverage runs. Looking at the [nyc github repo](https://github.com/istanbuljs/nyc#caching), they recommend enabling caching to only instrument the code once for better results and more performant testing.