### PR TITLE
Upgrade dependencies; support React 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - v8
   - v6
-  - v4
 after_script:
   - 'npm run coveralls'
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theming",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Unified CSSinJS theming solution for React",
   "main": "dist/cjs",
   "module": "dist/esm",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "theming",
-  "version": "1.2.0",
+  "version": "1.1.0",
   "description": "Unified CSSinJS theming solution for React",
   "main": "dist/cjs",
   "module": "dist/esm",

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "eslint-plugin-require-path-exists": "^1.1.7",
     "npm-run-all": "^4.0.2",
     "nyc": "^11.0.2",
+    "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1"
@@ -95,7 +96,9 @@
     "brcast": "^3.0.1",
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
-    "prop-types": "^15.5.8",
-    "react": "^16.0.0"
+    "prop-types": "^15.5.8"
+  },
+  "peerDependencies": {
+    "react": ">=0.15"
   }
 }

--- a/package.json
+++ b/package.json
@@ -67,18 +67,19 @@
   },
   "homepage": "https://github.com/iamstarkov/theming#readme",
   "devDependencies": {
-    "ava": "^0.21.0",
+    "ava": "^0.22.0",
     "babel-cli": "^6.24.1",
-    "babel-eslint": "^7.2.3",
+    "babel-eslint": "^8.0.1",
     "babel-preset-env": "^1.4.0",
     "babel-preset-es2017": "^6.24.1",
     "babel-preset-react": "^6.24.1",
     "babel-preset-stage-0": "^6.24.1",
     "babel-register": "^6.24.1",
-    "browser-env": "2.0.31",
-    "coveralls": "^2.13.1",
+    "browser-env": "^3.2.1",
+    "coveralls": "3.0.0",
     "cross-env": "^5.0.1",
-    "enzyme": "^2.8.2",
+    "enzyme": "^3.1.0",
+    "enzyme-adapter-react-16": "^1.0.2",
     "eslint": "^4.1.0",
     "eslint-config-pedant": "^0.10.0",
     "eslint-config-prettier": "^2.1.0",
@@ -86,15 +87,15 @@
     "eslint-plugin-require-path-exists": "^1.1.7",
     "npm-run-all": "^4.0.2",
     "nyc": "^11.0.2",
-    "react-dom": "^15.5.4",
-    "react-test-renderer": "^15.5.4",
+    "react-dom": "^16.0.0",
+    "react-test-renderer": "^16.0.0",
     "rimraf": "^2.6.1"
   },
   "dependencies": {
-    "brcast": "^2.0.0",
+    "brcast": "^3.0.1",
     "is-function": "^1.0.1",
     "is-plain-object": "^2.0.1",
     "prop-types": "^15.5.8",
-    "react": "^15.5.4"
+    "react": "^16.0.0"
   }
 }

--- a/src/create-theme-listener.test.js
+++ b/src/create-theme-listener.test.js
@@ -2,12 +2,15 @@ import test from 'ava';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import createBroadcast from 'brcast';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import isFunction from 'is-function';
 import isPainObject from 'is-plain-object';
 import { getChannel, Pure, mountOptions, getInterceptor } from './test-helpers';
 import CHANNEL from './channel';
 import createThemeListener from './create-theme-listener';
+
+configure({ adapter: new Adapter() });
 
 test(`createThemeListener's type`, t => {
   const actual = isFunction(createThemeListener);

--- a/src/create-theme-provider.js
+++ b/src/create-theme-provider.js
@@ -65,7 +65,7 @@ export default function createThemeProvider(CHANNEL = channel) {
     componentDidMount() {
       // create a new subscription for keeping track of outer theme, if present
       if (this.context[CHANNEL]) {
-        this.unsubscribe = this.context[CHANNEL].subscribe(this.setOuterTheme);
+        this.subscriptionId = this.context[CHANNEL].subscribe(this.setOuterTheme);
       }
     }
 
@@ -84,8 +84,9 @@ export default function createThemeProvider(CHANNEL = channel) {
     }
 
     componentWillUnmount() {
-      if (typeof this.unsubscribe === 'function') {
-        this.unsubscribe();
+      if (this.subscriptionId !== undefined) {
+        this.context[CHANNEL].unsubscribe(this.subscriptionId);
+        delete this.subscriptionId;
       }
     }
 

--- a/src/create-theme-provider.test.js
+++ b/src/create-theme-provider.test.js
@@ -53,25 +53,25 @@ test(`ThemeProvider unsubscribes on unmounting`, t => {
   const ThemeProvider = createThemeProvider();
   const theme = { themed: true };
   const broadcast = createBroadcast(theme);
-  const unsubscribed = getInterceptor(false);
 
   const wrapper = mount(
     <ThemeProvider theme={theme} />,
     mountOptions(broadcast),
   );
 
+  const { subscriptionId } = wrapper.instance();
   t.true(wrapper.instance().subscriptionId !== undefined, 'brcast subscriptionId is undefined');
   t.true(typeof wrapper.instance().subscriptionId === 'number', 'brcast subscriptionId expected to be number');
 
-  t.false(unsubscribed());
+  const subscription = getInterceptor(subscriptionId);
 
   const brcastInst = wrapper.context(channel);
-  brcastInst.unsubscribe = () => unsubscribed(true);
+  brcastInst.unsubscribe = (id) => subscription(id);
   wrapper.setContext({[channel]: brcastInst});
 
   wrapper.unmount();
 
-  t.true(unsubscribed(), `ThemeProvider should unsubscribe on unmounting`);
+  t.true(subscription() === subscriptionId, `ThemeProvider should unsubscribe on unmounting`);
 });
 
 test(`ThemeProvider and not a plain object theme`, t => {

--- a/src/create-theme-provider.test.js
+++ b/src/create-theme-provider.test.js
@@ -1,12 +1,15 @@
 import test from 'ava';
 import React, { Component } from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 import isFunction from 'is-function';
 import createThemeProvider from './create-theme-provider';
 import channel from './channel';
 // import createBroadcast from './create-broadcast';
 const createBroadcast = require('brcast');
+
+configure({ adapter: new Adapter() });
 
 import {
   getChannel,

--- a/src/create-theme-provider.test.js
+++ b/src/create-theme-provider.test.js
@@ -60,9 +60,15 @@ test(`ThemeProvider unsubscribes on unmounting`, t => {
     mountOptions(broadcast),
   );
 
+  t.true(wrapper.instance().subscriptionId !== undefined, 'brcast subscriptionId is undefined');
+  t.true(typeof wrapper.instance().subscriptionId === 'number', 'brcast subscriptionId expected to be number');
+
   t.false(unsubscribed());
 
-  wrapper.instance().unsubscribe = () => unsubscribed(true);
+  const brcastInst = wrapper.context(channel);
+  brcastInst.unsubscribe = () => unsubscribed(true);
+  wrapper.setContext({[channel]: brcastInst});
+
   wrapper.unmount();
 
   t.true(unsubscribed(), `ThemeProvider should unsubscribe on unmounting`);

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -1,6 +1,7 @@
 import test from 'ava';
 import React, { Component } from 'react';
-import { mount, shallow } from 'enzyme';
+import { mount, shallow, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 
 import isFunction from 'is-function';
 import createWithTheme from './create-with-theme';
@@ -14,6 +15,8 @@ import {
   mountOptions,
   getInterceptor,
 } from './test-helpers';
+
+configure({ adapter: new Adapter() });
 
 test(`createWithTheme's type`, t => {
   const actual = isFunction(createWithTheme);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,11 +1,14 @@
 import test from 'ava';
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, configure } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import isFunction from 'is-function';
 import isPlainObject from 'is-plain-object';
 import { Trap, Pure, Comp, getInterceptor, getChannel } from './test-helpers';
 
 import { channel, createTheming, ThemeProvider, withTheme } from './index';
+
+configure({ adapter: new Adapter() });
 
 test(`createTheming's type`, t => {
   const actual = isFunction(createTheming);


### PR DESCRIPTION
This is a minimal set of changes to upgrade all dependencies and create compatibility with React 16

* Upgraded all dependencies to latest versions
* Refactored enzyme tests to use appropriate adapter (`enzyme-adapter-react-16`)
* Removed React as a regular dependency and converted to peer and dev

There are warnings in the tests about needing to shim `requestAnimationFrame` and also noise from Exceptions that are purposely thrown... but all 53 tests pass.  I looked into introducing a React error boundary (`componentDidCatch`) to catch and handle the errors but we really want them to throw back to the test harness and be handled there.  So while it's a a bit noisy I think it's correct.  The `requestAnimationFrame` warnings are annoying and I'm not finding an easy way to fix them with `ava` -- but it could be that I'm not that familiar with `ava`. 

Fixes #43 