### PR TITLE
Added exporting the default context

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/theming.js": {
-    "bundled": 55914,
-    "minified": 19199,
-    "gzipped": 6118
+    "bundled": 55913,
+    "minified": 19204,
+    "gzipped": 6119
   },
   "dist/theming.min.js": {
-    "bundled": 26101,
-    "minified": 9883,
-    "gzipped": 3612
+    "bundled": 26100,
+    "minified": 9888,
+    "gzipped": 3613
   },
   "dist/theming.cjs.js": {
-    "bundled": 4704,
-    "minified": 2794,
-    "gzipped": 1075
+    "bundled": 4703,
+    "minified": 2793,
+    "gzipped": 1074
   },
   "dist/theming.esm.js": {
-    "bundled": 4325,
-    "minified": 2489,
-    "gzipped": 1013,
+    "bundled": 4308,
+    "minified": 2472,
+    "gzipped": 1003,
     "treeshaked": {
       "rollup": {
         "code": 1830,

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,23 +1,23 @@
 {
   "dist/theming.js": {
-    "bundled": 55879,
-    "minified": 19179,
-    "gzipped": 6108
+    "bundled": 55914,
+    "minified": 19199,
+    "gzipped": 6118
   },
   "dist/theming.min.js": {
-    "bundled": 26066,
-    "minified": 9863,
-    "gzipped": 3600
+    "bundled": 26101,
+    "minified": 9883,
+    "gzipped": 3612
   },
   "dist/theming.cjs.js": {
-    "bundled": 4670,
-    "minified": 2763,
-    "gzipped": 1067
+    "bundled": 4704,
+    "minified": 2794,
+    "gzipped": 1075
   },
   "dist/theming.esm.js": {
-    "bundled": 4298,
-    "minified": 2463,
-    "gzipped": 1004,
+    "bundled": 4325,
+    "minified": 2489,
+    "gzipped": 1013,
     "treeshaked": {
       "rollup": {
         "code": 1830,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 - Align flow and TypeScript types so they export the same interfaces ([#60](https://github.com/cssinjs/theming/pull/60))
 - Improve withTheme HoC, added support for innerRef and improved typings ([#61](https://github.com/cssinjs/theming/pull/61))
+- Export the default ThemeContext ([#62](https://github.com/cssinjs/theming/pull/62))
 
 ### 2.0.0 (2018-10-24)
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const augment = outerTheme =>
 *Required*  
 Type: `PropTypes.element`
 
-### withTheme(component)
+### withTheme(component, options)
 
 React High-Order component, which maps context to theme prop.
 
@@ -214,6 +214,21 @@ const App = () => (
 export default App;
 ```
 
+#### options
+ 
+Type: `Object`
+
+The options currently only contains one property.
+
+##### forwardInnerRef
+
+Type: `Boolean`
+Default: `false`
+
+This will actually just forward the `innerRef` property to the nested component.
+Otherwise the `innerRef` will be set as the `ref` prop of the wrapped component.
+This is most useful when building a Higher-Order-Component which uses `withTheme` to not have the ref on your Higher-Order-Component.
+
 ### createTheming(context)
 
 Function to create `ThemeProvider` and `withTheme` with custom context.
@@ -240,6 +255,15 @@ export default {
   withTheme,
   ThemeProvider,
 };
+```
+
+## ThemeContext
+
+We export the default ThemeContext so you can use it with the new `static contextType` with classes or even the new React Hooks API.
+This is the context which also the exported `withTheme` and `ThemeProvider` use.
+
+```js
+import { ThemeContext } from 'theming';
 ```
 
 ## Credits

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,8 +31,10 @@ declare function createTheming<Theme>(context: Context<Theme>): Theming<Theme>;
 
 declare const withTheme: WithThemeFactory<DefaultTheme>;
 declare const ThemeProvider: WithThemeFactory<DefaultTheme>;
+declare const context: Context<{}>;
 
 export {
+    context,
     createTheming,
     withTheme,
     ThemeProvider,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -31,10 +31,10 @@ declare function createTheming<Theme>(context: Context<Theme>): Theming<Theme>;
 
 declare const withTheme: WithThemeFactory<DefaultTheme>;
 declare const ThemeProvider: WithThemeFactory<DefaultTheme>;
-declare const context: Context<{}>;
+declare const ThemeContext: Context<{}>;
 
 export {
-    context,
+    ThemeContext,
     createTheming,
     withTheme,
     ThemeProvider,

--- a/src/index.js
+++ b/src/index.js
@@ -29,6 +29,7 @@ const {
 export type { Theming };
 
 export {
+  defaultContext as context,
   withTheme,
   createTheming,
   ThemeProvider,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ interface Theming {
   ThemeProvider: $Call<ExtractReturnType, typeof createThemeProvider>,
 }
 
-const defaultContext = createReactContext({});
+const ThemeContext = createReactContext({});
 
 function createTheming(context: Context<{}>): Theming {
   return {
@@ -24,12 +24,12 @@ function createTheming(context: Context<{}>): Theming {
 const {
   withTheme,
   ThemeProvider,
-} = createTheming(defaultContext);
+} = createTheming(ThemeContext);
 
 export type { Theming };
 
 export {
-  defaultContext as context,
+  ThemeContext,
   withTheme,
   createTheming,
   ThemeProvider,


### PR DESCRIPTION
This will make it possible to use the default context with the new React hooks