### PR TITLE
Improved createTheming API

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/theming.js": {
-    "bundled": 58821,
-    "minified": 20127,
-    "gzipped": 6303
+    "bundled": 58581,
+    "minified": 20061,
+    "gzipped": 6277
   },
   "dist/theming.min.js": {
-    "bundled": 26244,
-    "minified": 9977,
-    "gzipped": 3646
+    "bundled": 26004,
+    "minified": 9911,
+    "gzipped": 3616
   },
   "dist/theming.cjs.js": {
-    "bundled": 4703,
-    "minified": 2793,
-    "gzipped": 1074
+    "bundled": 4466,
+    "minified": 2727,
+    "gzipped": 1029
   },
   "dist/theming.esm.js": {
-    "bundled": 4308,
-    "minified": 2472,
-    "gzipped": 1003,
+    "bundled": 4071,
+    "minified": 2406,
+    "gzipped": 962,
     "treeshaked": {
       "rollup": {
-        "code": 1830,
+        "code": 1756,
         "import_statements": 179
       },
       "webpack": {
-        "code": 3102
+        "code": 3036
       }
     }
   }

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ const augment = outerTheme =>
 *Required*  
 Type: `PropTypes.element`
 
-### withTheme(component, options)
+### withTheme(component)
 
 React High-Order component, which maps context to theme prop.
 
@@ -213,21 +213,6 @@ const App = () => (
 
 export default App;
 ```
-
-#### options
- 
-Type: `Object`
-
-The options currently only contains one property.
-
-##### forwardInnerRef
-
-Type: `Boolean`
-Default: `false`
-
-This will actually just forward the `innerRef` property to the nested component.
-Otherwise the `innerRef` will be set as the `ref` prop of the wrapped component.
-This is most useful when building a Higher-Order-Component which uses `withTheme` to not have the ref on your Higher-Order-Component.
 
 ### createTheming(context)
 

--- a/src/create-with-theme.js
+++ b/src/create-with-theme.js
@@ -5,7 +5,6 @@ import { type Context } from 'create-react-context';
 import hoist from 'hoist-non-react-statics';
 import getDisplayName from 'react-display-name';
 
-type Options = { forwardInnerRef?: boolean };
 type OuterPropsType<InnerProps, InnerComponent, Theme> = $Diff<InnerProps, { theme: Theme }> & {
   theme?: Theme,
   innerRef?: (instance: ElementRef<InnerComponent> | null) => void
@@ -17,21 +16,16 @@ export default function createWithTheme<Theme: {}>(context: Context<Theme>) {
     InnerProps: InnerPropsType<Theme>,
     InnerComponent: ComponentType<InnerProps>,
     OuterProps: OuterPropsType<InnerProps, InnerComponent, Theme>,
-  >(
-    Component: InnerComponent,
-    { forwardInnerRef = false }: Options = {},
-  ): ComponentType<OuterProps> {
+  >(Component: InnerComponent): ComponentType<OuterProps> {
     function withTheme(props: OuterProps) {
-      // $FlowFixMe
       const { innerRef, ...otherProps } = props;
-
-      otherProps[forwardInnerRef ? 'innerRef' : 'ref'] = innerRef;
 
       return (
         <context.Consumer>
           {theme => (
             <Component
               theme={theme}
+              ref={innerRef}
               {...otherProps}
             />
           )}

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -83,17 +83,6 @@ test('innerRef should set the ref prop on the wrapped component', (t) => {
   t.deepEqual(refComp !== null && refComp.inner, true);
 });
 
-test('should forward the innerRef to the wrapped component when forwardInnerRef is true', (t) => {
-  const context = createReactContext({});
-  const WithTheme = createWithTheme(context)(FunctionalComponent, { forwardInnerRef: true });
-  const innerRef = () => undefined;
-  const { root } = TestRenderer.create((
-    <WithTheme innerRef={innerRef} />
-  ));
-
-  t.true(root.findByType(FunctionalComponent).props.innerRef === innerRef);
-});
-
 test('withTheme(Comp) hoists non-react static class properties', (t) => {
   const context = createReactContext({});
   const withTheme = createWithTheme(context);

--- a/src/index.js
+++ b/src/index.js
@@ -5,17 +5,21 @@ import createReactContext, { type Context } from 'create-react-context';
 import createThemeProvider, { type ThemeProviderProps } from './create-theme-provider';
 import createWithTheme from './create-with-theme';
 
-type ExtractReturnType = <ReturnType>((context: Context<{}>) => ReturnType) => ReturnType;
+type ExtractReturnType<Theme> = <ReturnType>(
+  (context: Context<Theme>) => ReturnType
+) => ReturnType;
 
-interface Theming {
-  withTheme: $Call<ExtractReturnType, typeof createWithTheme>,
-  ThemeProvider: $Call<ExtractReturnType, typeof createThemeProvider>,
+interface Theming<Theme> {
+  context: Context<Theme>,
+  withTheme: $Call<ExtractReturnType<Theme>, typeof createWithTheme>,
+  ThemeProvider: $Call<ExtractReturnType<Theme>, typeof createThemeProvider>,
 }
 
 const ThemeContext = createReactContext<{}>({});
 
-function createTheming(context: Context<{}>): Theming {
+function createTheming<Theme: {}>(context: Context<Theme>): Theming<Theme> {
   return {
+    context,
     withTheme: createWithTheme(context),
     ThemeProvider: createThemeProvider(context),
   };

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -20,7 +20,7 @@ test('createTheming()\'s key names', (t) => {
   const context = createReactContext({});
   const theming = createTheming(context);
   const actual = Object.keys(theming);
-  const expected = ['withTheme', 'ThemeProvider', 'context'];
+  const expected = ['context', 'withTheme', 'ThemeProvider'];
 
   t.deepEqual(
     actual,

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -20,7 +20,7 @@ test('createTheming()\'s key names', (t) => {
   const context = createReactContext({});
   const theming = createTheming(context);
   const actual = Object.keys(theming);
-  const expected = ['withTheme', 'ThemeProvider'];
+  const expected = ['withTheme', 'ThemeProvider', 'context'];
 
   t.deepEqual(
     actual,


### PR DESCRIPTION
- Added returning the context on the Theming API
- Added generic type to flow Theming interface
- Removed the option for `forwardInnerRef` as this should be handled by using context.Consumer directly