### PR TITLE
Forward ref support

### DIFF
--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,21 +1,21 @@
 {
   "dist/theming.js": {
-    "bundled": 50287,
+    "bundled": 50307,
     "minified": 16661,
     "gzipped": 5259
   },
   "dist/theming.min.js": {
-    "bundled": 18493,
+    "bundled": 18513,
     "minified": 7153,
     "gzipped": 2674
   },
   "dist/theming.cjs.js": {
-    "bundled": 5228,
+    "bundled": 5246,
     "minified": 3378,
     "gzipped": 1201
   },
   "dist/theming.esm.js": {
-    "bundled": 4784,
+    "bundled": 4802,
     "minified": 3006,
     "gzipped": 1124,
     "treeshaked": {

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/theming.js": {
-    "bundled": 50516,
-    "minified": 16637,
-    "gzipped": 5267
+    "bundled": 50287,
+    "minified": 16661,
+    "gzipped": 5259
   },
   "dist/theming.min.js": {
-    "bundled": 18722,
-    "minified": 7129,
-    "gzipped": 2680
+    "bundled": 18493,
+    "minified": 7153,
+    "gzipped": 2674
   },
   "dist/theming.cjs.js": {
-    "bundled": 5451,
-    "minified": 3354,
-    "gzipped": 1206
+    "bundled": 5228,
+    "minified": 3378,
+    "gzipped": 1201
   },
   "dist/theming.esm.js": {
-    "bundled": 5007,
-    "minified": 2982,
-    "gzipped": 1128,
+    "bundled": 4784,
+    "minified": 3006,
+    "gzipped": 1124,
     "treeshaked": {
       "rollup": {
-        "code": 1861,
+        "code": 1885,
         "import_statements": 163
       },
       "webpack": {
-        "code": 3404
+        "code": 3428
       }
     }
   }

--- a/.size-snapshot.json
+++ b/.size-snapshot.json
@@ -1,30 +1,30 @@
 {
   "dist/theming.js": {
-    "bundled": 50965,
-    "minified": 16787,
-    "gzipped": 5332
+    "bundled": 50516,
+    "minified": 16637,
+    "gzipped": 5267
   },
   "dist/theming.min.js": {
-    "bundled": 19171,
-    "minified": 7279,
-    "gzipped": 2754
+    "bundled": 18722,
+    "minified": 7129,
+    "gzipped": 2680
   },
   "dist/theming.cjs.js": {
-    "bundled": 5872,
-    "minified": 3547,
-    "gzipped": 1287
+    "bundled": 5451,
+    "minified": 3354,
+    "gzipped": 1206
   },
   "dist/theming.esm.js": {
-    "bundled": 5437,
-    "minified": 3184,
-    "gzipped": 1210,
+    "bundled": 5007,
+    "minified": 2982,
+    "gzipped": 1128,
     "treeshaked": {
       "rollup": {
-        "code": 2303,
+        "code": 1861,
         "import_statements": 163
       },
       "webpack": {
-        "code": 3552
+        "code": 3404
       }
     }
   }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### 3.0 (unreleased)
 
 - Upgrade to React 16.3 and cache the calculation of the theme object ([#74](https://github.com/cssinjs/theming/pull/74))
+- Add support for the new forward ref API and deprecate the `innerRef` prop ([#75](https://github.com/cssinjs/theming/pull/75))
 
 ### 2.2.0 (2018-11-16)
 

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "coveralls": "^3.0.0",
     "eslint": "^5.8.0",
     "eslint-config-jss": "^5.0.1",
-    "flow-bin": "^0.85.0",
+    "flow-bin": "^0.88.0",
     "nyc": "^13.1.0",
     "react": "^16.6.0",
     "react-test-renderer": "^16.6.0",

--- a/src/create-with-theme.js
+++ b/src/create-with-theme.js
@@ -8,10 +8,11 @@ import isObject from './is-object';
 
 export default function createWithTheme<Theme>(context: Context<Theme>) {
   return function hoc<
-    InnerProps: {},
+    InnerProps,
     InnerComponent: ComponentType<InnerProps>,
-    OuterProps: $Diff<InnerProps, { theme: Theme }>,
+    OuterProps: { ...InnerProps, theme?: $NonMaybeType<Theme> },
   >(Component: InnerComponent): ComponentType<OuterProps> {
+    // $FlowFixMe
     const withTheme = React.forwardRef((props, ref) => (
       <context.Consumer>
         {(theme) => {

--- a/src/create-with-theme.js
+++ b/src/create-with-theme.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { type ComponentType, type Ref, type Context } from 'react';
+import React, { type ComponentType, type Context } from 'react';
 import hoist from 'hoist-non-react-statics';
 import getDisplayName from 'react-display-name';
 import warning from 'warning';
@@ -10,27 +10,23 @@ export default function createWithTheme<Theme>(context: Context<Theme>) {
   return function hoc<
     InnerProps: {},
     InnerComponent: ComponentType<InnerProps>,
-    OuterProps: $Diff<InnerProps, { theme: Theme }> & { innerRef?: Ref<InnerComponent> },
+    OuterProps: $Diff<InnerProps, { theme: Theme }>,
   >(Component: InnerComponent): ComponentType<OuterProps> {
-    function withTheme(props: OuterProps) {
-      const { innerRef, ...otherProps } = props;
+    const withTheme = React.forwardRef((props, ref) => (
+      <context.Consumer>
+        {(theme) => {
+          warning(isObject(theme), '[theming] Please use withTheme only with the ThemeProvider');
 
-      return (
-        <context.Consumer>
-          {(theme) => {
-            warning(isObject(theme), '[theming] Please use withTheme only with the ThemeProvider');
-
-            return (
-              <Component
-                theme={theme}
-                ref={innerRef}
-                {...otherProps}
-              />
-            );
-          }}
-        </context.Consumer>
-      );
-    }
+          return (
+            <Component
+              theme={theme}
+              ref={ref}
+              {...props}
+            />
+          );
+        }}
+      </context.Consumer>
+    ));
 
     withTheme.displayName = `WithTheme(${getDisplayName(Component)})`;
 

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -69,7 +69,7 @@ test('should allow overriding the prop from the outer props', (t) => {
   t.true(root.findByType(FunctionalComponent).props.theme === otherTheme);
 });
 
-test('innerRef should set the ref prop on the wrapped component', (t) => {
+test('normal refs should just work and correctly be forwarded', (t) => {
   const theme = {};
   const context = React.createContext<{}>(theme);
   const withTheme = createWithTheme(context);
@@ -80,7 +80,7 @@ test('innerRef should set the ref prop on the wrapped component', (t) => {
   const WithTheme = withTheme(ClassComponent);
 
   TestRenderer.create((
-    <WithTheme innerRef={innerRef} />
+    <WithTheme ref={innerRef} />
   ));
 
   t.deepEqual(refComp !== null && refComp.inner, true);

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -8,7 +8,6 @@ import createWithTheme from './create-with-theme';
 
 type Props = { theme: {} };
 
-// eslint-disable-next-line no-unused-vars
 const FunctionalComponent = (props: Props) => null;
 
 class ClassComponent extends React.Component<Props> {
@@ -58,10 +57,9 @@ test('should pass the value of the Provider', (t) => {
 });
 
 test('should allow overriding the prop from the outer props', (t) => {
-  const theme = {};
   const otherTheme = {};
-  const context = React.createContext(theme);
-  const WithTheme = createWithTheme(context)(FunctionalComponent);
+  const context = React.createContext<{}>({});
+  const WithTheme = createWithTheme<{}>(context)(FunctionalComponent);
   const { root } = TestRenderer.create((
     <WithTheme theme={otherTheme} />
   ));
@@ -70,14 +68,12 @@ test('should allow overriding the prop from the outer props', (t) => {
 });
 
 test('normal refs should just work and correctly be forwarded', (t) => {
-  const theme = {};
-  const context = React.createContext<{}>(theme);
-  const withTheme = createWithTheme(context);
+  const context = React.createContext({});
+  const WithTheme = createWithTheme(context)(ClassComponent);
   let refComp = null;
   const innerRef = (comp) => {
     refComp = comp;
   };
-  const WithTheme = withTheme(ClassComponent);
 
   TestRenderer.create((
     <WithTheme ref={innerRef} />
@@ -107,7 +103,7 @@ test('withTheme(Comp) hoists non-react static class properties', (t) => {
 test('should warn when theme isn\'t an object', (t) => {
   const spy = sinon.spy(console, 'error');
 
-  const context = React.createContext(null);
+  const context = React.createContext<{} | void>();
   const withTheme = createWithTheme(context);
   const WithTheme = withTheme(ClassComponent);
 

--- a/src/create-with-theme.test.js
+++ b/src/create-with-theme.test.js
@@ -8,6 +8,7 @@ import createWithTheme from './create-with-theme';
 
 type Props = { theme: {} };
 
+// eslint-disable-next-line no-unused-vars
 const FunctionalComponent = (props: Props) => null;
 
 class ClassComponent extends React.Component<Props> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,12 +2,10 @@ import * as React from 'react';
 
 type DefaultTheme = object | null;
 
-type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
-
 type WithThemeFactory<Theme> = <
     InnerProps extends { theme: NonNullable<Theme> },
     InnerComponent extends React.ComponentType<InnerProps>,
-    OuterProps extends Omit<InnerProps, { theme: NonNullable<Theme> }>,
+    OuterProps extends InnerProps & { theme?: NonNullable<Theme> },
 >(comp: InnerComponent) => React.ComponentType<OuterProps>;
 
 interface ThemeProviderProps<Theme> {

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -7,7 +7,7 @@ type Omit<T, K> = Pick<T, Exclude<keyof T, K>>;
 type WithThemeFactory<Theme> = <
     InnerProps extends { theme: NonNullable<Theme> },
     InnerComponent extends React.ComponentType<InnerProps>,
-    OuterProps extends Omit<InnerProps, { theme: NonNullable<Theme> }> & { innerRef?: React.Ref<InnerComponent> },
+    OuterProps extends Omit<InnerProps, { theme: NonNullable<Theme> }>,
 >(comp: InnerComponent) => React.ComponentType<OuterProps>;
 
 interface ThemeProviderProps<Theme> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,10 +2959,10 @@ flat-cache@^1.2.1:
     graceful-fs "^4.1.2"
     write "^0.2.1"
 
-flow-bin@^0.85.0:
-  version "0.85.0"
-  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.85.0.tgz#a3ca80748a35a071d5bbb2fcd61d64d977fc53a6"
-  integrity sha512-ougBA2q6Rn9sZrjZQ9r5pTFxCotlGouySpD2yRIuq5AYwwfIT8HHhVMeSwrN5qJayjHINLJyrnsSkkPCZyfMrQ==
+flow-bin@^0.88.0:
+  version "0.88.0"
+  resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.88.0.tgz#e4c7bd93da2331f6ac1733fbe484b1b0c52eb548"
+  integrity sha512-SnUCuhHP0JZaXQ83w4iTthfTInAg8DIBZCo1xIqDhFmQ6XNEMYMwYhPoMQyELRrkbTpyCYmf4g93y0UQw0dibw==
 
 flush-write-stream@^1.0.0:
   version "1.0.3"


### PR DESCRIPTION
This removes the `innerRef` prop from `withTheme` and replaces it with the `forwardRef` API.