### PR TITLE
Move react-jss types to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@babel/preset-flow": "^7.0.0",
     "@babel/preset-react": "^7.0.0",
     "@babel/register": "^7.0.0",
+    "@types/react": "^16.4.18",
     "ava": "^1.0.0-rc.1",
     "babel-plugin-dev-expression": "^0.2.1",
     "coveralls": "^3.0.0",
@@ -88,7 +89,6 @@
     "typescript": "^3.1.6"
   },
   "dependencies": {
-    "@types/react": "^16.4.18",
     "hoist-non-react-statics": "^3.1.0",
     "prop-types": "^15.5.8",
     "react-display-name": "^0.2.4",


### PR DESCRIPTION
Installing external types can have a problem when the end user also installs the same types package.

As we shouldn't force someone to install the `@types/react` package, I just moved to the dev dependencies. I think we can expect someone to have the appropriate package installed