### PR TITLE
Support passing a custom theme type-argument to useTheme

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -15,7 +15,7 @@ interface ThemeProviderProps<Theme> {
 
 type ThemeProviderFactory<Theme> = React.ComponentType<ThemeProviderProps<Theme>>;
 
-type UseThemeFactory<Theme> = () => Theme;
+type UseThemeFactory<Theme> = <CustomTheme = Theme>() => CustomTheme;
 
 interface Theming<Theme> {
     context: React.Context<Theme>,


### PR DESCRIPTION
In react-jss, you can pass an optional type-argument to createUseStyles (e.g. `createUseStyles<MyTheme>()`), which will use `MyTheme` instead of `DefaultTheme`.

However, this option is not available for react-jss's `useTheme`, the type definitions for which come from this package.

I've changed it so you can supply an optional type argument like this:
```ts
const { ... } = useTheme<MyTheme>();
```

which will override the `DefaultTheme` defined here:

https://github.com/cssinjs/theming/blob/dabb2cb/src/index.d.ts#L3

